### PR TITLE
fix for "Undefined: Paywithmybank"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Trustly Android Example App
 
+fork of TrustlyInc/trustly-android-example with local changes to get it working for our specific environment at Pala.
+
+
 The purpose of this example app is to demonstrate how to implement and use the [Trustly Android SDK](https://amer.developers.trustly.com/payments/docs/android-quickstart).
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 fork of TrustlyInc/trustly-android-example with local changes to get it working for our specific environment at Pala.
 
-
 The purpose of this example app is to demonstrate how to implement and use the [Trustly Android SDK](https://amer.developers.trustly.com/payments/docs/android-quickstart).
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Trustly Android Example App
 
+## NOTE: Pala Interactive fork
+
 fork of TrustlyInc/trustly-android-example with local changes to get it working for our specific environment at Pala.
 
 The purpose of this example app is to demonstrate how to implement and use the [Trustly Android SDK](https://amer.developers.trustly.com/payments/docs/android-quickstart).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 fork of TrustlyInc/trustly-android-example with local changes to get it working for our specific environment at Pala.
 
+
+## Original README.md below this line:
+
 The purpose of this example app is to demonstrate how to implement and use the [Trustly Android SDK](https://amer.developers.trustly.com/payments/docs/android-quickstart).
 
 

--- a/app/src/main/java/net/trustly/paywithmybanksdkdemoandroid/ui/LightBoxActivity.kt
+++ b/app/src/main/java/net/trustly/paywithmybanksdkdemoandroid/ui/LightBoxActivity.kt
@@ -34,7 +34,11 @@ class LightBoxActivity : AppCompatActivity() {
     override fun onRestart() {
         super.onRestart()
 
-        lightBoxWidget.proceedToChooseAccount()
+        /**
+         * patch to deal with  "Uncaught ReferenceError: Paywithmybank is not defined"  message in Android system log
+         */
+        //lightBoxWidget.proceedToChooseAccount()
+        lightBoxWidget.hybrid( "javascript:PayWithMyBank.proceedToChooseAccount()", "#return", "#cancel")
     }
 
     private fun redirectToScreen(callback: Callback) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.4.0' apply false
-    id 'com.android.library' version '7.4.0' apply false
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.21' apply false
 }


### PR DESCRIPTION
WARNING: this pull request is prepared for review purposes only.    It is not an official proposed fix but rather a workaround based on guesses derived from single-stepping into the PayWithMyBank-2.2.1.aar library using Android Studio.    The actual software contract and meaning of the hybrid() method (shown below) is unknown.   This may or may not work properly in the long term.

Change description:
This pull request changes the source file by adding a patch to deal with the "Uncaught ReferenceError: Paywithmybank is not defined" message in Android system log. Instead of calling lightBoxWidget.proceedToChooseAccount(), the patch invokes the lightBoxWidget.hybrid() method that sends a JavaScript command to the PayWithMyBank widget to proceed to choose an account. The hybrid() method takes three arguments: the JavaScript command, the selector for the "return" button, and the selector for the "cancel" button. This change should fix the error and allow the user to proceed with the PayWithMyBank process.