### PR TITLE
fix for Undefined: PayWithMyBank error (likely casing error in Javascript global)

### DIFF
--- a/app/src/main/java/net/trustly/paywithmybanksdkdemoandroid/ui/LightBoxActivity.kt
+++ b/app/src/main/java/net/trustly/paywithmybanksdkdemoandroid/ui/LightBoxActivity.kt
@@ -34,7 +34,11 @@ class LightBoxActivity : AppCompatActivity() {
     override fun onRestart() {
         super.onRestart()
 
-        lightBoxWidget.proceedToChooseAccount()
+        /**
+         * patch to deal with  "Uncaught ReferenceError: Paywithmybank is not defined"  message in Android system log
+         */
+        //lightBoxWidget.proceedToChooseAccount()
+        lightBoxWidget.hybrid( "javascript:PayWithMyBank.proceedToChooseAccount()", "#return", "#cancel")
     }
 
     private fun redirectToScreen(callback: Callback) {


### PR DESCRIPTION
WARNING: this pull request in for INFORMATIONAL PURPOSES, and DISCUSSION.    The hybrid() method employed in the fix is a hack that might possibly work in its present form, but it is NOT A LONG TERM SOLUTION. 