### PR TITLE
[DEV-295254] Prevent redirection popup by closing the activity

### DIFF
--- a/app/src/main/java/net/trustly/trustlysdkdemoandroid/ui/RedirectActivity.kt
+++ b/app/src/main/java/net/trustly/trustlysdkdemoandroid/ui/RedirectActivity.kt
@@ -1,6 +1,8 @@
 package net.trustly.trustlysdkdemoandroid.ui
 
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import androidx.appcompat.app.AppCompatActivity
 
 class RedirectActivity : AppCompatActivity() {
@@ -10,7 +12,9 @@ class RedirectActivity : AppCompatActivity() {
 
         //TODO This validation is related with DeepLink strategy and will be included into SDK
         if (intent.data!!.scheme!!.contains("http")) {
-            finish()
+            Handler(Looper.getMainLooper()).postDelayed({
+                finish()
+            }, 700)
         }
     }
 


### PR DESCRIPTION
### JIRA
https://trustly.atlassian.net/browse/DEV-295254

### Description

When redirect from Custom Tabs to the app, which contains the App Link intent filter, a popup click interaction ir required to the user. In order to prevent showing this, we just close the redirection Activity with some delay.

---

### Requirements

- [x] Changes were properly tested (attach evidence if applicable)
- [x] Repository's code-style/linting compliant

---

### Evidence

## Popup for redirection
[deeplink_oauth_popup.webm](https://github.com/user-attachments/assets/1974918d-2abb-47fa-af78-e3e3aeb89803)

## Dismiss popup and redirect
[deeplink_oauth.webm](https://github.com/user-attachments/assets/9ecd3592-6aed-4fee-9a0e-414d70f231d2)

---